### PR TITLE
Fixed seg fault due to out of bounds segment index

### DIFF
--- a/linefit_ground_segmentation/src/ground_segmentation.cc
+++ b/linefit_ground_segmentation/src/ground_segmentation.cc
@@ -265,8 +265,9 @@ void GroundSegmentation::insertionThread(const PointCloud& cloud,
       const double angle = std::atan2(point.y, point.x);
       const unsigned int bin_index = (range - r_min) / bin_step;
       const unsigned int segment_index = (angle + M_PI) / segment_step;
-      segments_[segment_index == params_.n_segments ? 0 : segment_index][bin_index].addPoint(range, point.z);
-      bin_index_[i] = std::make_pair(segment_index, bin_index);
+      const unsigned int segment_index_clamped = segment_index == params_.n_segments ? 0 : segment_index;
+      segments_[segment_index_clamped][bin_index].addPoint(range, point.z);
+      bin_index_[i] = std::make_pair(segment_index_clamped, bin_index);
     }
     else {
       bin_index_[i] = std::make_pair<int, int>(-1, -1);


### PR DESCRIPTION
Fixes issue #21.
This was actually the same issue as #5, but when I fixed that one it did not save the correct index, but the out of bounds one.